### PR TITLE
Fix double bucket in URL when location is auto (fixes #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ module.exports = ({ env }) => ({
         /**
          * Set this Option to store the CDN URL of your files and not the R2 endpoint URL in your DB.
          * Can be used in Cloudflare R2 with Domain-Access or Public URL: https://pub-<YOUR_PULIC_BUCKET_ID>.r2.dev
+         * This option is required to upload files larger than 5MB, and is highly recommended to be set.
          * Check the cloudflare docs for the setup: https://developers.cloudflare.com/r2/data-access/public-buckets/#enable-public-access-for-your-bucket
          */
         cloudflarePublicAccessUrl: env("CF_PUBLIC_ACCESS_URL"),

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,12 +53,21 @@ module.exports = {
             if (err) {
               return reject(err);
             }
-            // Set the bucket file url. 
-            // If there is a Custom endpoint for data access set, replace the upload endpoint with the read enpoint URL
-            if(config.cloudflarePublicAccessUrl){
-              file.url = config.cloudflarePublicAccessUrl.replace(/\/$/g,'')+'/'+data.Key;
+
+            // Strip bucket name from key if Location is auto
+            const key = data.Location === 'auto' && data.Key.startsWith(`${config.params.Bucket}/`)
+              ? data.Key.replace(`${config.params.Bucket}/`, '')
+              : data.Key;
+
+            // Set the bucket file URL.
+            // If there is a custom endpoint for data access set, replace the upload endpoint with the read enpoint URL.
+            // Otherwise, use location returned from S3 API if it's not auto (may happen if file >5MB).
+            if (config.cloudflarePublicAccessUrl) {
+              file.url = config.cloudflarePublicAccessUrl.replace(/\/$/g, '') + '/' + key;
+            } else if (data.Location !== 'auto') {
+              file.url = data.Location;
             } else {
-              file.url = data.Location
+              // TODO: Handle missing location
             }
 
             // check if https is included in file URL

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,10 @@ module.exports = {
       ...config,
     });
 
+    if (!config.cloudflarePublicAccessUrl) {
+      process.emitWarning("strapi-provider-cloudflare-r2 requires cloudflarePublicAccessUrl to upload files larger than 5MB. https://github.com/trieb-work/strapi-provider-cloudflare-r2#provider-configuration")
+    }
+
     const upload = (file, customParams = {}) =>
       new Promise((resolve, reject) => {
         // upload file on S3 bucket
@@ -69,7 +73,7 @@ module.exports = {
             } else if (data.Location !== 'auto') {
               file.url = data.Location;
             } else {
-              // TODO: Handle missing location
+              throw new Error("Cloudflare S3 API returned no file location and cloudflarePublicAccessUrl is not set. strapi-provider-cloudflare-r2 requires cloudflarePublicAccessUrl to upload files larger than 5MB. https://github.com/trieb-work/strapi-provider-cloudflare-r2#provider-configuration")
             }
 
             // check if https is included in file URL

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,6 +54,8 @@ module.exports = {
               return reject(err);
             }
 
+            // When a file is >5MB, Location is set to "auto" and the bucket name is prepended to the key.
+
             // Strip bucket name from key if Location is auto
             const key = data.Location === 'auto' && data.Key.startsWith(`${config.params.Bucket}/`)
               ? data.Key.replace(`${config.params.Bucket}/`, '')
@@ -61,7 +63,7 @@ module.exports = {
 
             // Set the bucket file URL.
             // If there is a custom endpoint for data access set, replace the upload endpoint with the read enpoint URL.
-            // Otherwise, use location returned from S3 API if it's not auto (may happen if file >5MB).
+            // Otherwise, use location returned from S3 API if it's not "auto"
             if (config.cloudflarePublicAccessUrl) {
               file.url = config.cloudflarePublicAccessUrl.replace(/\/$/g, '') + '/' + key;
             } else if (data.Location !== 'auto') {


### PR DESCRIPTION
Fixed https://github.com/trieb-work/strapi-provider-cloudflare-r2/issues/8

Not sure what behavior should be when `cloudflarePublicAccessUrl` is not set and `Location` is `auto`, since we have no way of building the result URL.