### PR TITLE
Added bucket pool option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,9 @@ yarn add strapi-provider-cloudflare-r2
 # using npm
 npm install strapi-provider-cloudflare-r2 --save
 
-# using pnpm 
+# using pnpm
 pnpm add strapi-provider-cloudflare-r2
 ```
-
-
 
 ## Configuration
 
@@ -52,6 +50,12 @@ module.exports = ({ env }) => ({
          * Check the cloudflare docs for the setup: https://developers.cloudflare.com/r2/data-access/public-buckets/#enable-public-access-for-your-bucket
          */
         cloudflarePublicAccessUrl: env("CF_PUBLIC_ACCESS_URL"),
+        /**
+         * Sets if all assets should be uploaded in the root dir regardless the strapi folder.
+         * It is useful because strapi sets folder names with numbers, not by user's input folder name
+         * By default it is false
+         */
+        pool: false,
       },
       actionOptions: {
         upload: {},

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,7 @@ module.exports = {
     const upload = (file, customParams = {}) =>
       new Promise((resolve, reject) => {
         // upload file on S3 bucket
-        const { Key } = getPathKey(file, config.upload);
+        const { Key } = getPathKey(file, config.pool);
         S3.upload(
           {
             Key,

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,12 +34,15 @@ function removeLeadingSlash(str) {
   return str.replace(/^\//, "");
 }
 
-function getPathKey(file) {
+function getPathKey(file, pool = false) {
   const filePath = file.path ? `${file.path}/` : "";
-  const path =
-    file.folderPath && file.folderPath !== "/"
-      ? `${removeLeadingSlash(file.folderPath)}/${filePath}`
-      : filePath;
+  let path = filePath;
+  if (!pool) {
+    path =
+      file.folderPath && file.folderPath !== "/"
+        ? `${removeLeadingSlash(file.folderPath)}/${filePath}`
+        : filePath;
+  }
 
   const Key = `${path}${file.hash}${file.ext}`;
   return { path, Key };
@@ -72,7 +75,7 @@ module.exports = {
     const upload = (file, customParams = {}) =>
       new Promise((resolve, reject) => {
         // upload file on S3 bucket
-        const { Key } = getPathKey(file);
+        const { Key } = getPathKey(file, config.upload);
         S3.upload(
           {
             Key,
@@ -131,7 +134,7 @@ module.exports = {
       delete(file, customParams = {}) {
         return new Promise((resolve, reject) => {
           // delete file on S3 bucket
-          const { Key } = getPathKey(file);
+          const { Key } = getPathKey(file, config.upload);
           S3.deleteObject(
             {
               Key,


### PR DESCRIPTION
Strapi sets folder names in the cloudflare bucket as numbers (1, 2, 3) and sometimes it is better to have all media in the same root folder. This is like a datalake some people may be interested in. In this PR, I included the option to config the bucket as a pool, but by default it is set to false. When user activates this option in the strapi's plugin configuration, all media (images, videos, documents...) will be uploaded to the main cloudflare's bucket folder regardless the folders created by strapi.